### PR TITLE
set retention period on log group in example

### DIFF
--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -24,7 +24,8 @@ module "humio_logger" {
 }
 
 resource "aws_cloudwatch_log_group" "humio_logger" {
-  name = "humio-logger-ci-logs"
+  name              = "humio-logger-ci-logs"
+  retention_in_days = 7
 }
 
 module "acs_vpn" {


### PR DESCRIPTION
I'm making this change in response to the following email from the cloud office.

```
Hello AWS Account Owner! 

The following Log Group in your AWS Account was found to have a Retention Policy set to 'Never Expire'. To prevent increasing charges over time we have just set the Retention Policy to only retain these logs for one year. You are welcome to set a different retention policy if needed. If not, no further action is required on your part. 

(To view resources make sure you are logged into the corresponding account and region) 
humio-logger-ci-logs which is in the us-west-2 region of the byu-oit-terraform-dev account. Account owners: jgubler@byu.edu

humio-logger-dev-logs which is in the us-west-2 region of the byu-oit-terraform-dev account. Account owners: jgubler@byu.edu


If you have any questions please reach out to the #cloud-office slack channel or our email below.  

Thanks so much for helping us keep our accounts clean, secure, and low-cost as possible! 
```